### PR TITLE
Update Module Resolution to `NodeNext`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "outDir": "dist",
     "sourceMap": true,


### PR DESCRIPTION
This pull request adjusts the module and module resolution configurations in the `tsconfig.json` file to utilize `NodeNext`. This change is made in response to the issue reported in #47, and it is expected to address the problem.