### PR TITLE
Exclude Formatting for `main` Directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "bundle": "tsc && ncc build dist/main.mjs -o main",
-    "check": "sort-package-json && prettier --write . !dist && eslint src",
+    "check": "sort-package-json && prettier --write . !main && eslint src",
     "prepack": "tsc",
     "test": "jest"
   },


### PR DESCRIPTION
This pull request excludes the `main` directory from being formatted by the `check` command. The `main` directory contains the bundled entry point script, generated by the `bundle` command, and should retain its style as per the formatting applied during its generation.

This modification ensures that the formatting process does not affect the `main` directory, maintaining consistency with the script's original style. The pull request closes #73.