### PR TITLE
Treat Action Node.js Package as Private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ coverage/
 dist/
 docs/
 node_modules/
-
-package.tgz

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "action-starter",
+  "private": true,
   "version": "0.1.0",
   "description": "A GitHub Action starter project",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,25 +1,7 @@
 {
   "name": "action-starter",
   "private": true,
-  "version": "0.1.0",
-  "description": "A GitHub Action starter project",
-  "keywords": [
-    "keyword",
-    "other-keyword"
-  ],
-  "homepage": "https://github.com/threeal/action-starter#readme",
-  "bugs": {
-    "url": "https://github.com/threeal/action-starter/issues",
-    "email": "threeal@github.com"
-  },
-  "repository": "github:threeal/action-starter",
-  "license": "Unlicense",
-  "author": "Alfi Maulana <alfi.maulana.f@gmail.com>",
   "type": "module",
-  "main": "dist/index.js",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "bundle": "tsc && ncc build dist/main.mjs -o main",
     "check": "sort-package-json && prettier --write . !main && eslint src",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "bundle": "tsc && ncc build dist/main.mjs -o main",
     "check": "sort-package-json && prettier --write . !main && eslint src",
-    "prepack": "tsc",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request treats the Action Node.js Package as private by introducing the following changes:
- Set `private` to `true` in the `package.json` file.
- Remove some unused properties in the `package.json` file.
- Remove the `prepack` script.

It closes #72.