### PR TITLE
Use Git Ignore in ESLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "bundle": "tsc && ncc build dist/main.mjs -o main",
-    "check": "prettier --write . !main && eslint src package.json",
+    "check": "prettier --write . !main && eslint --ignore-path .gitignore .",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
This pull requests modify ESLint to use `.gitignore` for ignoring files. It closes #97.