### PR TITLE
Separate `check` Command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,8 +29,11 @@ jobs:
       - name: Install Dependencies
         run: yarn install
 
-      - name: Check Package
-        run: yarn check
+      - name: Check Format
+        run: yarn format
+
+      - name: Check Lint
+        run: yarn lint
 
       - name: Bundle Package
         run: yarn bundle

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "bundle": "tsc && ncc build dist/main.mjs -o main",
-    "check": "prettier --write . !main && eslint --ignore-path .gitignore .",
+    "format": "prettier --write . !main",
+    "lint": "eslint --ignore-path .gitignore .",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request separates the `check` command to `format` and `lint` commands. It closes #100.