### PR TITLE
Run Only on Latest Ubuntu in Test Package Job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,11 +7,7 @@ on:
 jobs:
   test-package:
     name: Test Package
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
This pull request adjusts the `test-package` job to exclusively run on the latest Ubuntu version, removing Matrix OS support for that job. It resolves #106.