### PR TITLE
Rename Bundle Command to Build Command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,8 +29,8 @@ jobs:
       - name: Install Dependencies
         run: yarn install
 
-      - name: Bundle Package
-        run: yarn bundle
+      - name: Build Package
+        run: yarn build
 
       - name: Check Differences
         run: git diff --exit-code HEAD

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "bundle": "tsc && ncc build dist/main.mjs -o main",
+    "build": "tsc && ncc build dist/main.mjs -o main",
     "format": "prettier --write . !main",
     "lint": "eslint --ignore-path .gitignore .",
     "test": "tsc && jest"


### PR DESCRIPTION
This pull request simply renames the `bundle` command to `build` command in the `package.json` file.