### PR TITLE
Sparse Checkout for Action Files in Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,9 +77,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+        with:
+          path: mkdir-action
 
       - name: Create Directory
-        uses: ./
+        uses: ./mkdir-action
         with:
           path: parent/child
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,6 +84,9 @@ jobs:
         uses: ./mkdir-action
         with:
           path: parent/child
+          sparse-checkout: |
+            action.yaml
+            main
 
       - name: Check Directory
         shell: bash


### PR DESCRIPTION
This pull request modifies the checkout step in the `test-action` job of `test` workflow as follows:
- Checkout to `mkdir-action` directory instead to default current directory.
- Sparse checkout `action.yaml` file and `main` directory only instead of the whole files.

It closes #116.