### PR TITLE
Call Yarn Command From Corepack Command in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,10 +27,10 @@ jobs:
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Dependencies
-        run: yarn install
+        run: corepack yarn install
 
       - name: Build Package
-        run: yarn build
+        run: corepack yarn build
 
       - name: Check Differences
         run: git diff --exit-code HEAD

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
         run: corepack enable yarn
 
       - name: Check Yarn Version
-        run: yarn set version stable && git diff --exit-code HEAD
+        run: corepack yarn set version stable && git diff --exit-code HEAD
 
       - name: Cache Dependencies
         uses: actions/cache@v3.3.2
@@ -30,13 +30,13 @@ jobs:
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Dependencies
-        run: yarn install
+        run: corepack yarn install
 
       - name: Check Format
-        run: yarn format && git diff --exit-code HEAD
+        run: corepack yarn format && git diff --exit-code HEAD
 
       - name: Check Lint
-        run: yarn lint
+        run: corepack yarn lint
 
   test-package:
     name: Test Package
@@ -60,10 +60,10 @@ jobs:
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Dependencies
-        run: yarn install
+        run: corepack yarn install
 
       - name: Test Package
-        run: yarn test
+        run: corepack yarn test
         env:
           NODE_OPTIONS: --experimental-vm-modules
 


### PR DESCRIPTION
This pull request modifies the `yarn` command to be called with `corepack yarn` instead in the workflows. It closes #120.