### PR TITLE
Fix Distribution Directory Rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "root": true,
+  "ignorePatterns": ["dist"],
   "extends": ["eslint:recommended", "prettier"],
   "parserOptions": {
     "ecmaVersion": 2022,

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-dist/index.mjs -diff linguist-generated
+dist/** -diff linguist-generated
 yarn.lock -diff linguist-generated


### PR DESCRIPTION
This pull request addresses rules related to the `dist` directory with the following changes:

- Excludes the `dist` directory from ESLint checks.
- Specifies Git attributes for the entire `dist` directory, not just the `dist/index.mjs` file.