### PR TITLE
Fix Sparse Checkout in Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,14 +79,14 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           path: mkdir-action
+          sparse-checkout: |
+            action.yaml
+            dist
 
       - name: Create Directory
         uses: ./mkdir-action
         with:
           path: parent/child
-          sparse-checkout: |
-            action.yaml
-            dist
 
       - name: Check Directory
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,6 +82,7 @@ jobs:
           sparse-checkout: |
             action.yaml
             dist
+          sparse-checkout-cone-mode: false
 
       - name: Create Directory
         uses: ./mkdir-action


### PR DESCRIPTION
This pull request resolves the sparse checkout issue by disabling cone mode during checkout. It also fix bug in which the `sparse-checkout` inputs is not being set in the correct step. See https://github.com/threeal/yarn-install-action/pull/31 for more information about this changes.