### PR TITLE
Use Yarn Install Action in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,17 +17,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Enable Yarn
-        run: corepack enable yarn
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install Dependencies
-        run: corepack yarn install
+        uses: threeal/yarn-install-action@v1.0.0
 
       - name: Build Package
         run: corepack yarn build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,20 +17,11 @@ jobs:
         with:
           node-version: latest
 
-      - name: Enable Yarn
-        run: corepack enable yarn
+      - name: Install Dependencies
+        uses: threeal/yarn-install-action@v1.0.0
 
       - name: Check Yarn Version
         run: corepack yarn set version stable && git diff --exit-code HEAD
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
-      - name: Install Dependencies
-        run: corepack yarn install
 
       - name: Check Format
         run: corepack yarn format && git diff --exit-code HEAD
@@ -50,17 +41,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Enable Yarn
-        run: corepack enable yarn
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install Dependencies
-        run: corepack yarn install
+        uses: threeal/yarn-install-action@v1.0.0
 
       - name: Test Package
         run: corepack yarn test


### PR DESCRIPTION
This pull request modifies all workflows in this project to use [Yarn Install Action](https://github.com/threeal/yarn-install-action/) for installing dependencies for this project. It closes #123.