### PR TITLE
Remove Test Match Option in Jest Configuration

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -7,6 +7,5 @@
       "lines": 100,
       "statements": 100
     }
-  },
-  "testMatch": ["**/*.test.js"]
+  }
 }


### PR DESCRIPTION
This pull request removes the `testMatch` option from the Jest configuration file. It closes #134.