### PR TITLE
Remove Check Yarn Version Step in Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,11 +20,6 @@ jobs:
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0
 
-      - name: Check Yarn Version
-        run: |
-          corepack yarn set version stable
-          git diff --exit-code HEAD
-
       - name: Check Format
         run: |
           corepack yarn format


### PR DESCRIPTION
This pull request resolves #166 by simply removing the "Check Yarn Version" step from the `check-package` job of the `test` workflow.