### PR TITLE
Use Default ncc Build Output

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && ncc build src/index.mjs -o dist",
+    "build": "tsc && ncc build src/index.mjs",
     "format": "prettier --write . !dist",
     "lint": "eslint --ignore-path .gitignore .",
     "test": "tsc && jest"


### PR DESCRIPTION
This pull request resolves #176 by removing the `-o dist` option when calling the `ncc` command, effectively causing the `ncc` command to output the build result to the default directory, which is also the `dist` directory.