### PR TITLE
Fix Git Ignore Pattern for JavaScript Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 coverage/
 node_modules/
 
-src/*.mjs
+src/**/*.mjs


### PR DESCRIPTION
This pull request resolves #182 by fixing the pattern in the `.gitignore` file to ignore JavaScript files using `src/**/*.mjs`.