### PR TITLE
Simplify ESLint Configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "ignorePatterns": ["dist"],
-  "extends": ["eslint:recommended", "prettier"],
+  "extends": ["eslint:recommended"],
   "parserOptions": {
     "ecmaVersion": 2022,
     "sourceType": "module"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,11 +10,7 @@
     {
       "files": ["**/*.mts", "**/*.ts"],
       "extends": ["plugin:@typescript-eslint/recommended"],
-      "parser": "@typescript-eslint/parser",
-      "parserOptions": {
-        "project": ["tsconfig.json"]
-      },
-      "plugins": ["@typescript-eslint", "eslint-plugin-tsdoc"],
+      "plugins": ["eslint-plugin-tsdoc"],
       "rules": {
         "tsdoc/syntax": "error"
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
   },
   "overrides": [
     {
-      "files": ["**/*.mts", "**/*.ts"],
+      "files": ["**/*.?([cm])ts"],
       "extends": ["plugin:@typescript-eslint/recommended"],
       "plugins": ["eslint-plugin-tsdoc"],
       "rules": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@typescript-eslint/parser": "^6.21.0",
     "@vercel/ncc": "^0.38.1",
     "eslint": "^8.56.0",
-    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-json-files": "^4.1.0",
     "eslint-plugin-tsdoc": "^0.2.17",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,17 +1999,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "eslint-config-prettier@npm:9.1.0"
-  peerDependencies:
-    eslint: ">=7.0.0"
-  bin:
-    eslint-config-prettier: bin/cli.js
-  checksum: 6d332694b36bc9ac6fdb18d3ca2f6ac42afa2ad61f0493e89226950a7091e38981b66bac2b47ba39d15b73fff2cd32c78b850a9cf9eed9ca9a96bfb2f3a2f10d
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-json-files@npm:^4.1.0":
   version: 4.1.0
   resolution: "eslint-plugin-json-files@npm:4.1.0"
@@ -4191,7 +4180,6 @@ __metadata:
     "@typescript-eslint/parser": "npm:^6.21.0"
     "@vercel/ncc": "npm:^0.38.1"
     eslint: "npm:^8.56.0"
-    eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-json-files: "npm:^4.1.0"
     eslint-plugin-tsdoc: "npm:^0.2.17"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
This pull request resolves #198 by introducing the following changes to the ESLint configuration:
- Simplifies the configuration for TypeScript files by removing the `@typescript-eslint/parser` parser and the `@typescript-eslint` plugins configuration because they are already set when extending from the `plugin:@typescript-eslint/recommended`.
- Removes the `eslint-config-prettier` configuration because it is no longer needed.
- Simplifies the glob pattern for TypeScript files to `**/*.?([cm])ts`.