### PR TITLE
Utilize Module Mocking in Sample Testing

### DIFF
--- a/.env.yarn
+++ b/.env.yarn
@@ -1,0 +1,1 @@
+NODE_OPTIONS=--experimental-vm-modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.env.yarn
 !.eslint*
 !.git*
 !.yarnrc.yml

--- a/jest.config.json
+++ b/jest.config.json
@@ -12,6 +12,7 @@
     "^(\\.{1,2}/.*)\\.js$": "$1"
   },
   "preset": "ts-jest/presets/default-esm",
+  "setupFilesAfterEnv": ["jest-extended/all"],
   "transform": {
     "^.+\\.ts$": ["ts-jest", { "useESM": true }]
   },

--- a/jest.config.json
+++ b/jest.config.json
@@ -11,6 +11,7 @@
   "moduleNameMapper": {
     "^(\\.{1,2}/.*)\\.js$": "$1"
   },
+  "preset": "ts-jest/presets/default-esm",
   "transform": {
     "^.+\\.ts$": ["ts-jest", { "useESM": true }]
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@actions/core": "^1.10.1"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.20",
     "@typescript-eslint/eslint-plugin": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-tsdoc": "^0.2.17",
     "jest": "^29.7.0",
+    "jest-extended": "^4.0.2",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "typescript": "^5.3.3"

--- a/src/mkdir.test.ts
+++ b/src/mkdir.test.ts
@@ -1,4 +1,5 @@
 import { jest } from "@jest/globals";
+import "jest-extended";
 
 jest.unstable_mockModule("fs", () => ({
   default: {
@@ -12,8 +13,8 @@ it("should create a directory recursively", async () => {
 
   mkdirRecursive("path/to/new/directory");
 
-  expect(fs.mkdirSync).toHaveBeenCalledTimes(1);
-  expect(fs.mkdirSync).toHaveBeenLastCalledWith("path/to/new/directory", {
-    recursive: true,
-  });
+  expect(fs.mkdirSync).toHaveBeenCalledExactlyOnceWith(
+    "path/to/new/directory",
+    { recursive: true },
+  );
 });

--- a/src/mkdir.test.ts
+++ b/src/mkdir.test.ts
@@ -1,23 +1,19 @@
-import * as path from "path";
-import fs from "fs";
-import { mkdirRecursive } from "./mkdir.js";
-import os from "os";
+import { jest } from "@jest/globals";
 
-describe("create directory", () => {
-  const dirname = path.join(os.tmpdir(), "parent", "child");
+jest.unstable_mockModule("fs", () => ({
+  default: {
+    mkdirSync: jest.fn(),
+  },
+}));
 
-  beforeAll(() => {
-    fs.rmSync(dirname, { force: true, recursive: true });
-  });
-  afterAll(() => {
-    fs.rmSync(dirname, { force: true, recursive: true });
-  });
+it("should create a directory recursively", async () => {
+  const fs = (await import("fs")).default;
+  const { mkdirRecursive } = await import("./mkdir.js");
 
-  it("should create a temporary directory", () => {
-    fs.rmSync(dirname, { force: true, recursive: true });
-    expect(fs.existsSync(dirname)).toBe(false);
+  mkdirRecursive("path/to/new/directory");
 
-    mkdirRecursive(dirname);
-    expect(fs.existsSync(dirname)).toBe(true);
+  expect(fs.mkdirSync).toHaveBeenCalledTimes(1);
+  expect(fs.mkdirSync).toHaveBeenLastCalledWith("path/to/new/directory", {
+    recursive: true,
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2849,7 +2849,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.7.0":
+"jest-diff@npm:^29.0.0, jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
   dependencies:
@@ -2897,7 +2897,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-get-type@npm:^29.6.3":
+"jest-extended@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "jest-extended@npm:4.0.2"
+  dependencies:
+    jest-diff: "npm:^29.0.0"
+    jest-get-type: "npm:^29.0.0"
+  peerDependencies:
+    jest: ">=27.2.5"
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  checksum: 10c0/305fdb6885ab71755830b70690b8db6ea6fd9adca92360ea1a37c0d2fa6567a68b57178dd7707d112fc57b01ab75b66f28a1c550ed0e6b1b8628600a812c2277
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^29.0.0, jest-get-type@npm:^29.6.3":
   version: 29.6.3
   resolution: "jest-get-type@npm:29.6.3"
   checksum: 10c0/552e7a97a983d3c2d4e412a44eb7de0430ff773dd99f7500962c268d6dfbfa431d7d08f919c9d960530e5f7f78eb47f267ad9b318265e5092b3ff9ede0db7c2b
@@ -4045,6 +4060,7 @@ __metadata:
     eslint: "npm:^8.57.0"
     eslint-plugin-tsdoc: "npm:^0.2.17"
     jest: "npm:^29.7.0"
+    jest-extended: "npm:^4.0.2"
     prettier: "npm:^3.2.5"
     ts-jest: "npm:^29.1.2"
     typescript: "npm:^5.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4036,6 +4036,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@actions/core": "npm:^1.10.1"
+    "@jest/globals": "npm:^29.7.0"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.20"
     "@typescript-eslint/eslint-plugin": "npm:^7.0.2"


### PR DESCRIPTION
This pull request resolves #225 by utilizing module mocking in the sample testing. Additionally, it integrates [jest-extended](https://www.npmjs.com/package/jest-extended) to assist in writing assertions for mocked functions.