### PR TITLE
Set Root Workspace Name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "root",
   "private": true,
   "type": "module",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,9 +4046,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"root-workspace-0b6124@workspace:.":
+"root@workspace:.":
   version: 0.0.0-use.local
-  resolution: "root-workspace-0b6124@workspace:."
+  resolution: "root@workspace:."
   dependencies:
     "@actions/core": "npm:^1.10.1"
     "@jest/globals": "npm:^29.7.0"


### PR DESCRIPTION
This pull request resolves #243 by simply setting the root workspace name to `root`.