### PR TITLE
Add Quick Usage to Readme

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,9 @@ jobs:
             dist
           sparse-checkout-cone-mode: false
 
+      # Modify the following steps for testing your JavaScript action.
+      # Learn more: https://docs.github.com/en/actions/automating-builds-and-tests
+
       - name: Create Directory
         uses: ./mkdir-action
         with:

--- a/README.md
+++ b/README.md
@@ -19,4 +19,18 @@ A minimalistic [GitHub repository template](https://docs.github.com/en/repositor
 
 ## Usage
 
-Refer to [this wiki](https://github.com/threeal/action-starter/wiki) for information on how to use this template.
+> For detailed instructions on how to use this template, please refer to [the wiki](https://github.com/threeal/action-starter/wiki).
+
+- Create a new repository from this template.
+- Make the following changes to the new repository:
+  - Replace the [LICENSE](LICENSE) file.
+  - Update the content of the [README](README.md) file.
+  - Define the action information in the [action.yml](action.yml) file.
+  - Develop the action logic in the [src/index.ts](src/index.ts) file. Use these commands for development:
+    - `yarn install`: Initialize project dependencies.
+    - `yarn format`: Format the source code.
+    - `yarn lint`: Lint the source code.
+    - `yarn test`: Run unit tests. Write the unit tests in files with `*.test.ts` pattern.
+    - `yarn build`: Build the source code into a single file for distribution.
+  - Write tests for the action in the [test workflow](.github/workflows/test.yaml) file.
+- Finalize the action and cut the first release.


### PR DESCRIPTION
This pull request resolves #264 by simply updating the usage section with a quick usage guide and adding comments that guide on adding steps for testing the action.