### PR TITLE
Remove `main` Function

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26044,11 +26044,13 @@ function mkdirRecursive(path) {
 ;// CONCATENATED MODULE: ./src/index.ts
 
 
-async function main() {
+try {
     const path = core.getInput("path", { required: true });
     mkdirRecursive(path);
 }
-main().catch((err) => core.setFailed(err));
+catch (err) {
+    core.setFailed(err);
+}
 
 })();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import * as core from "@actions/core";
 import { mkdirRecursive } from "./mkdir.js";
 
-async function main() {
+try {
   const path = core.getInput("path", { required: true });
   mkdirRecursive(path);
+} catch (err) {
+  core.setFailed(err);
 }
-
-main().catch((err) => core.setFailed(err));


### PR DESCRIPTION
This pull request resolves #280 by removing the `main` function and moving its content to the top level.