### PR TITLE
Enable TypeScript Strict Configuration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26698,6 +26698,10 @@ var __webpack_exports__ = {};
 
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-core-npm-1.10.1-3cb1000b4d-10c0.zip/node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(2340);
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/catched-error-message-npm-0.0.1-9126a73d25-10c0.zip/node_modules/catched-error-message/dist/index.esm.js
+function r(r){return function(r){if("object"==typeof(e=r)&&null!==e&&"message"in e&&"string"==typeof e.message)return r;var e;try{return new Error(JSON.stringify(r))}catch(e){return new Error(String(r))}}(r).message}
+//# sourceMappingURL=index.esm.js.map
+
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __nccwpck_require__(7147);
 var external_fs_default = /*#__PURE__*/__nccwpck_require__.n(external_fs_);
@@ -26715,12 +26719,13 @@ function mkdirRecursive(path) {
 ;// CONCATENATED MODULE: ./src/index.ts
 
 
+
 try {
     const path = core.getInput("path", { required: true });
     mkdirRecursive(path);
 }
 catch (err) {
-    core.setFailed(err);
+    core.setFailed(r(err));
 }
 
 })();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@actions/core": "^1.10.1"
+    "@actions/core": "^1.10.1",
+    "catched-error-message": "^0.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import * as core from "@actions/core";
+import { getErrorMessage } from "catched-error-message";
 import { mkdirRecursive } from "./mkdir.js";
 
 try {
   const path = core.getInput("path", { required: true });
   mkdirRecursive(path);
 } catch (err) {
-  core.setFailed(err);
+  core.setFailed(getErrorMessage(err));
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "strict": true,
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,6 +1692,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"catched-error-message@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "catched-error-message@npm:0.0.1"
+  checksum: 10c0/1f10cd4323a73bec7a57b7495730e5dad9995120b04e85b5f654f7b40dc6a36320d95cc55e49cdf78753158e18790ef725e2ec7309ebced3acd6c9a557ac075b
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -4198,6 +4205,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.14.12"
     "@vercel/ncc": "npm:^0.38.1"
+    catched-error-message: "npm:^0.0.1"
     eslint: "npm:^9.8.0"
     jest: "npm:^29.7.0"
     jest-extended: "npm:^4.0.2"


### PR DESCRIPTION
This pull request resolves #366 by introducing the following changes:
- Uses the [catched-error-message](https://www.npmjs.com/package/catched-error-message) package to stringify caught errors.
- Enables TypeScript strict configuration.
- Configures TypeScript to skip library checks.