### PR TITLE
Remove Mocked Test in Sample Package

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1,6 +1,5 @@
-import 'node:fs';
+import fs from 'node:fs';
 import os from 'node:os';
-import fs from 'fs';
 
 /**
  * Retrieves the value of a GitHub Actions input.

--- a/jest.config.json
+++ b/jest.config.json
@@ -13,7 +13,6 @@
     "^(\\.{1,2}/.*)\\.js$": "$1"
   },
   "preset": "ts-jest/presets/default-esm",
-  "setupFilesAfterEnv": ["jest-extended/all"],
   "transform": {
     "^.+\\.ts$": ["ts-jest", { "useESM": true }]
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",
-    "@jest/globals": "^29.7.0",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
@@ -21,7 +20,6 @@
     "@types/node": "^22.1.0",
     "eslint": "^9.8.0",
     "jest": "^29.7.0",
-    "jest-extended": "^4.0.2",
     "prettier": "^3.3.3",
     "rollup": "^4.20.0",
     "ts-jest": "^29.2.4",

--- a/src/mkdir.test.ts
+++ b/src/mkdir.test.ts
@@ -1,20 +1,13 @@
-import { jest } from "@jest/globals";
-import "jest-extended";
-
-jest.unstable_mockModule("fs", () => ({
-  default: {
-    mkdirSync: jest.fn(),
-  },
-}));
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { mkdirRecursive } from "./mkdir.js";
 
 it("should create a directory recursively", async () => {
-  const fs = (await import("fs")).default;
-  const { mkdirRecursive } = await import("./mkdir.js");
+  if (fs.existsSync(path.join(os.tmpdir(), "path"))) {
+    fs.rmdirSync(path.join(os.tmpdir(), "path"), { recursive: true });
+  }
 
-  mkdirRecursive("path/to/new/directory");
-
-  expect(fs.mkdirSync).toHaveBeenCalledExactlyOnceWith(
-    "path/to/new/directory",
-    { recursive: true },
-  );
+  mkdirRecursive(path.join(os.tmpdir(), "path/to/new/directory"));
+  fs.existsSync(path.join(os.tmpdir(), "path/to/new/directory"));
 });

--- a/src/mkdir.ts
+++ b/src/mkdir.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 
 /**
  * Creates a directory recursively.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3232,7 +3232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.0.0, jest-diff@npm:^29.7.0":
+"jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
   dependencies:
@@ -3280,22 +3280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-extended@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "jest-extended@npm:4.0.2"
-  dependencies:
-    jest-diff: "npm:^29.0.0"
-    jest-get-type: "npm:^29.0.0"
-  peerDependencies:
-    jest: ">=27.2.5"
-  peerDependenciesMeta:
-    jest:
-      optional: true
-  checksum: 10c0/305fdb6885ab71755830b70690b8db6ea6fd9adca92360ea1a37c0d2fa6567a68b57178dd7707d112fc57b01ab75b66f28a1c550ed0e6b1b8628600a812c2277
-  languageName: node
-  linkType: hard
-
-"jest-get-type@npm:^29.0.0, jest-get-type@npm:^29.6.3":
+"jest-get-type@npm:^29.6.3":
   version: 29.6.3
   resolution: "jest-get-type@npm:29.6.3"
   checksum: 10c0/552e7a97a983d3c2d4e412a44eb7de0430ff773dd99f7500962c268d6dfbfa431d7d08f919c9d960530e5f7f78eb47f267ad9b318265e5092b3ff9ede0db7c2b
@@ -4570,7 +4555,6 @@ __metadata:
   resolution: "root@workspace:."
   dependencies:
     "@eslint/js": "npm:^9.8.0"
-    "@jest/globals": "npm:^29.7.0"
     "@rollup/plugin-commonjs": "npm:^26.0.1"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-typescript": "npm:^11.1.6"
@@ -4579,7 +4563,6 @@ __metadata:
     eslint: "npm:^9.8.0"
     gha-utils: "npm:^0.1.0"
     jest: "npm:^29.7.0"
-    jest-extended: "npm:^4.0.2"
     prettier: "npm:^3.3.3"
     rollup: "npm:^4.20.0"
     ts-jest: "npm:^29.2.4"


### PR DESCRIPTION
This pull request resolves #375 by replacing the mocked test in the sample package with testing using a real environment, effectively removing the need for `@jest/globals` and `jest-extended` as dependencies. It also fixes the `node:fs` import in the sample function.