### PR TITLE
Utilize Graceful Exit

### DIFF
--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -39,5 +39,5 @@ try {
 }
 catch (err) {
     logError(err);
-    process.exit(1);
+    process.exitCode = 1;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,5 +6,5 @@ try {
   mkdirRecursive(path);
 } catch (err) {
   logError(err);
-  process.exit(1);
+  process.exitCode = 1;
 }


### PR DESCRIPTION
This pull request resolves #473 by replacing the `process.exit()` function with setting the `process.exitCode` to implement a graceful exit.