### PR TITLE
Add Missing Lefthook Step Name

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,7 +24,8 @@ pre-commit:
       exclude:
         - src/*.test.ts
 
-    - run: pnpm rollup -c
+    - name: build action
+      run: pnpm rollup -c
       glob:
         - dist/*
         - src/*.ts


### PR DESCRIPTION
This pull request resolves #691 by adding a missing step name in the `lefthook.yml` file.