### PR TITLE
Check Test Coverage on All Files

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     coverage: {
-      all: false,
       enabled: true,
       reporter: ["text"],
       thresholds: { 100: true },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     coverage: {
       enabled: true,
-      reporter: ["text"],
+      reporter: "text",
       thresholds: { 100: true },
     },
   },


### PR DESCRIPTION
This pull request resolves #716 by removing the `test.coverage.all` configuration in `vitest.config.ts`, which by default makes Vitest check test coverage on all files. In doing so, this change also simplfy the `test.coverage.reporter` configuration in `vitest.config.ts` file.