### PR TITLE
Remove tslib From Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "lefthook": "^1.11.13",
     "prettier": "^3.5.3",
     "rollup": "^4.43.0",
-    "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.0",
     "vitest": "^3.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       rollup:
         specifier: ^4.43.0
         version: 4.43.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -2425,7 +2422,8 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
This pull request resolves #728 by removing the unused tslib package from the dependencies in this project.