### PR TITLE
Bump Node.js to Version 24.6.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=24.5.0
+use-node-version=24.6.0


### PR DESCRIPTION
This pull request bumps the Node.js version specified in the `.npmrc` file to version [24.6.0](https://github.com/nodejs/node/releases/tag/v24.6.0).