### PR TITLE
Make `.gitignore` rules for dot-prefixed files more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .*
-!.git*
+!.github/
+!.gitattributes
+!.gitignore
 !.npmrc
-!.prettier*
+!.prettierignore
+!.prettierrc.json
 
 node_modules/


### PR DESCRIPTION
This pull request resolves #942 by making the rules for including dot-prefixed files in `.gitignore` more specific.