### PR TITLE
Remove Lefthook from development dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ pnpm exec prettier --write . # fix formatting
 pnpm exec rollup -c          # build — outputs dist/main.bundle.mjs
 ```
 
-Pre-commit hooks (via Lefthook) automatically run formatting, linting, type checking, and building before each commit.
+Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), an external tool (not a dev dependency) that must be installed independently and set up with `lefthook install`. Hooks automatically run formatting, linting, type checking, and building before each commit.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ pnpm install
 
 For more information on pnpm, including adding dependencies or running tools, refer to [this documentation](https://pnpm.io/pnpm-cli).
 
+This template also uses [Lefthook](https://lefthook.dev/) to manage Git hooks. Lefthook is not installed as a project dependency and must be installed independently by following [this guide](https://lefthook.dev/installation/). Once installed, set up the Git hooks with:
+
+```sh
+lefthook install
+```
+
 ### Developing the Action
 
 Write the logic for the action in the [`src/main.ts`](./src/main.ts) file according to the project requirements. If you're new to [TypeScript](https://www.typescriptlang.org/), refer to [this documentation](https://www.typescriptlang.org/docs/) for guidance.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@vitest/coverage-v8": "^4.0.15",
     "eslint": "^10.3.0",
     "jiti": "^2.7.0",
-    "lefthook": "^2.1.1",
     "prettier": "^3.8.3",
     "prettier-plugin-organize-imports": "^4.3.0",
     "rollup": "^4.60.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
-      lefthook:
-        specifier: ^2.1.1
-        version: 2.1.1
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -844,60 +841,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  lefthook-darwin-arm64@2.1.1:
-    resolution: {integrity: sha512-O/RS1j03/Fnq5zCzEb2r7UOBsqPeBuf1C5pMkIJcO4TSE6hf3rhLUkcorKc2M5ni/n5zLGtzQUXHV08/fSAT3Q==}
-    cpu: [arm64]
-    os: [darwin]
-
-  lefthook-darwin-x64@2.1.1:
-    resolution: {integrity: sha512-mm/kdKl81ROPoYnj9XYk5JDqj+/6Al8w/SSPDfhItkLJyl4pqS+hWUOP6gDGrnuRk8S0DvJ2+hzhnDsQnZohWQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  lefthook-freebsd-arm64@2.1.1:
-    resolution: {integrity: sha512-F7JXlKmjxGqGbCWPLND0bVB4DMQezIe48pEwTlUQZbxh450c2gP5Q8FdttMZKOT163kBGGTqJAJSEC6zW+QSxA==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  lefthook-freebsd-x64@2.1.1:
-    resolution: {integrity: sha512-Po8/lJMqNzKSZPuEI46dLuWoBoXtAxCuRpeOh6DAV/M4RhBynaCu8rLMZ9BqF7cVbZEWoplOmYo6HdOuiYpCkQ==}
-    cpu: [x64]
-    os: [freebsd]
-
-  lefthook-linux-arm64@2.1.1:
-    resolution: {integrity: sha512-mI2ljFgPEqHxI8vrN9nKgnVu63Rz1KisDbPwlvs7BTYNwq3sncdK5ukpGR4zzWdh6saNJ5tCtHEtep5GQI11nw==}
-    cpu: [arm64]
-    os: [linux]
-
-  lefthook-linux-x64@2.1.1:
-    resolution: {integrity: sha512-m3G/FaxC+crxeg9XeaUuHfEoL+i9gbkg2Hp2KD2IcVVIxprqlyqf0Hb8zbLV2NMXuo5RSGokJu44oAoTO3Ou2g==}
-    cpu: [x64]
-    os: [linux]
-
-  lefthook-openbsd-arm64@2.1.1:
-    resolution: {integrity: sha512-gz/8FJPvhjOdOFt1GmFvuvDOe+W+BBRjoeAT1/mTgkN7HCXMXgqNjjvakQKQeGz1I1v08wXG1ZNf5y+T9XBCDQ==}
-    cpu: [arm64]
-    os: [openbsd]
-
-  lefthook-openbsd-x64@2.1.1:
-    resolution: {integrity: sha512-ch3lyMUtbmtWUufaQVn4IoEs/2hjK51XqaCdY1mh5ca//VctR1peknIwQ5feHu+vATCDviWQ7HsdNDewm3HMPg==}
-    cpu: [x64]
-    os: [openbsd]
-
-  lefthook-windows-arm64@2.1.1:
-    resolution: {integrity: sha512-mm3PZhKDs9FE/jQDimkfWxtoj9xQ2k8uw2MdhtC825bhvIh+MEi0WFj/MOW+ug0RBg0I55tGYzZ5aVuozAWpTQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  lefthook-windows-x64@2.1.1:
-    resolution: {integrity: sha512-1L2oGIzmhfOTxfwbe5mpSQ+m3ilpvGNymwIhn4UHq6hwHsUL6HEhODqx02GfBn6OXpVIr56bvdBAusjL/SVYGQ==}
-    cpu: [x64]
-    os: [win32]
-
-  lefthook@2.1.1:
-    resolution: {integrity: sha512-Tl9h9c+sG3ShzTHKuR3LAIblnnh+Mgxnm2Ul7yu9cu260Z27LEbO3V6Zw4YZFP59/2rlD42pt/llYsQCkkCFzw==}
-    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1881,49 +1824,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  lefthook-darwin-arm64@2.1.1:
-    optional: true
-
-  lefthook-darwin-x64@2.1.1:
-    optional: true
-
-  lefthook-freebsd-arm64@2.1.1:
-    optional: true
-
-  lefthook-freebsd-x64@2.1.1:
-    optional: true
-
-  lefthook-linux-arm64@2.1.1:
-    optional: true
-
-  lefthook-linux-x64@2.1.1:
-    optional: true
-
-  lefthook-openbsd-arm64@2.1.1:
-    optional: true
-
-  lefthook-openbsd-x64@2.1.1:
-    optional: true
-
-  lefthook-windows-arm64@2.1.1:
-    optional: true
-
-  lefthook-windows-x64@2.1.1:
-    optional: true
-
-  lefthook@2.1.1:
-    optionalDependencies:
-      lefthook-darwin-arm64: 2.1.1
-      lefthook-darwin-x64: 2.1.1
-      lefthook-freebsd-arm64: 2.1.1
-      lefthook-freebsd-x64: 2.1.1
-      lefthook-linux-arm64: 2.1.1
-      lefthook-linux-x64: 2.1.1
-      lefthook-openbsd-arm64: 2.1.1
-      lefthook-openbsd-x64: 2.1.1
-      lefthook-windows-arm64: 2.1.1
-      lefthook-windows-x64: 2.1.1
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
Closes #948

## Summary

- Removed `lefthook` from `devDependencies` in `package.json` and updated `pnpm-lock.yaml`
- Updated `README.md` to document Lefthook as an external tool requiring independent installation and `lefthook install`
- Updated `CLAUDE.md` to clarify Lefthook is not a dev dependency

## Test plan

- [ ] Verify `pnpm install` no longer installs Lefthook
- [ ] Verify pre-commit hooks still run correctly after installing Lefthook externally and running `lefthook install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)