### PR TITLE
Update CI to validate pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,35 +5,28 @@ on:
   push:
     branches: [main]
 jobs:
-  build:
-    name: Build
+  check:
+    name: Check
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+
+      - name: Install Lefthook
+        run: |
+          curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash
+          sudo apt install lefthook
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
         with:
           version: 10.33.4
 
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Check formatting
-        run: pnpm prettier --check .
-
-      - name: Check lint
-        run: pnpm eslint
-
-      - name: Check types
-        run: pnpm tsc
+      - name: Check pre-commit hook
+        run: lefthook run pre-commit --all-files
 
       - name: Test
         run: pnpm test
-
-      - name: Build
-        run: pnpm rollup -c && git diff --exit-code dist
 
   test:
     name: Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ pnpm exec prettier --write . # fix formatting
 pnpm exec rollup -c          # build — outputs dist/main.bundle.mjs
 ```
 
-Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), an external tool (not a dev dependency) that must be installed independently and set up with `lefthook install`. Hooks automatically run formatting, linting, type checking, and building before each commit.
+Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), an external tool (not a dev dependency) that must be installed independently and set up with `lefthook install`. Hooks automatically run formatting, linting, type checking, and building before each commit. CI also validates the pre-commit hook by running `lefthook run pre-commit --all-files`.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This template provides a basic GitHub Action project containing a sample [JavaSc
 - Uses [pnpm](https://pnpm.io/) as the package manager.
 - Supports formatting with [Prettier](https://prettier.io/), linting with [ESLint](https://eslint.org/), and testing with [Vitest](https://vitest.dev/).
 - Fixes formatting and linting during pre-commit hooks using [Lefthook](https://lefthook.dev/).
-- Preconfigured workflows for [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions).
+- Preconfigured workflows for [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions) that validate the pre-commit hook.
 
 ## Usage
 


### PR DESCRIPTION
Resolves #950.

## Summary

- Renames the `build` job to `check`
- Replaces individual check steps (install deps, formatting, lint, types, build) with Lefthook installation and `lefthook run pre-commit --all-files`
- Updates `CLAUDE.md` and `README.md` to reflect that CI validates the pre-commit hook

## Test plan

- [ ] CI passes on this PR
- [ ] `Check pre-commit hook` step covers dependency installation, formatting, linting, type checking, and building

🤖 Generated with [Claude Code](https://claude.com/claude-code)