### PR TITLE
Update README and guides to improve clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ pnpm exec prettier --write . # fix formatting
 pnpm exec rollup -c          # build — outputs dist/main.bundle.mjs
 ```
 
-Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), an external tool (not a dev dependency) that must be installed independently and set up with `lefthook install`. Hooks automatically run formatting, linting, type checking, and building before each commit. CI also validates the pre-commit hook by running `lefthook run pre-commit --all-files`.
+Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), set up with `lefthook install`. Hooks automatically run formatting, linting, type checking, and building before each commit. CI also validates the pre-commit hook by running `lefthook run pre-commit --all-files`.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,78 +1,96 @@
-<!-- TODO: Replace the content of this file with the new project description. -->
-
 # Action Starter
 
-A minimalist template for starting a new [GitHub Action](https://github.com/features/actions) project.
+A minimal template for building a [JavaScript GitHub Action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-javascript-action).
 
-This template provides a basic GitHub Action project containing a sample [JavaScript action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-javascript-action) written in [TypeScript](https://www.typescriptlang.org/), with built-in support for formatting, linting, testing, and continuous integration.
+## Getting Started
 
-## Key Features
+Create a new repository from this template on GitHub using [this link](https://github.com/new?template_name=action-starter&template_owner=threeal).
 
-- Minimal GitHub Action project written in TypeScript with [ESM](https://nodejs.org/api/esm.html) support.
-- Uses [pnpm](https://pnpm.io/) as the package manager.
-- Supports formatting with [Prettier](https://prettier.io/), linting with [ESLint](https://eslint.org/), and testing with [Vitest](https://vitest.dev/).
-- Fixes formatting and linting during pre-commit hooks using [Lefthook](https://lefthook.dev/).
-- Preconfigured workflows for [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions) that validate the pre-commit hook.
+Or clone it locally and point it at your own remote.
 
-## Usage
+## Setup
 
-This guide explains how to use this template to start a new GitHub Action project, from creation to release.
-
-### Create a New Project
-
-Follow [this link](https://github.com/new?template_name=action-starter&template_owner=threeal) to create a new project based on this template. For more information about creating a repository from a template on GitHub, refer to [this documentation](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
-
-Alternatively, you can clone this repository locally to begin using this template.
-
-### Choose a License
-
-By default, this template is [unlicensed](https://unlicense.org/). Before modifying this template, replace the [`LICENSE`](./LICENSE) file with the license to be used by the new project. For more information about licensing a repository, refer to [this documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository).
-
-Alternatively, you can remove the `LICENSE` file or leave it as-is to keep the new project unlicensed.
-
-### Update Project Information
-
-To replace the sample information in this template with details about your new project, complete the following steps:
-
-- Replace the content of this [`README.md`](./README.md) file with a description of the new project. For more information on adding READMEs to a project, refer to [this documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes).
-- Modify the action metadata in the [`action.yml`](./action.yml) file according to the new project specifications. For more details on the action metadata, refer to [this documentation](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions).
-
-> Note: You can also search for `TODO` comments for a list of information that needs to be replaced.
-
-### Set Up Tools
-
-This template uses [pnpm](https://pnpm.io/) as the package manager. If pnpm is not installed, follow [this guide](https://pnpm.io/installation) to install it. Then, install the project dependencies with:
+Install [pnpm](https://pnpm.io/), then install dependencies:
 
 ```sh
 pnpm install
 ```
 
-For more information on pnpm, including adding dependencies or running tools, refer to [this documentation](https://pnpm.io/pnpm-cli).
-
-This template also uses [Lefthook](https://lefthook.dev/) to manage Git hooks. Lefthook is not installed as a project dependency and must be installed independently by following [this guide](https://lefthook.dev/installation/). Once installed, set up the Git hooks with:
+Install [Lefthook](https://lefthook.dev/), then register the pre-commit hooks:
 
 ```sh
 lefthook install
 ```
 
-### Developing the Action
+## Customizing the Action
 
-Write the logic for the action in the [`src/main.ts`](./src/main.ts) file according to the project requirements. If you're new to [TypeScript](https://www.typescriptlang.org/), refer to [this documentation](https://www.typescriptlang.org/docs/) for guidance.
+### `action.yml`
 
-If the action will support pre- and post-steps, additional files like `src/pre.ts` and `src/post.ts` can be added. Just make sure to update the Rollup configuration in the [`rollup.config.js`](./rollup.config.js) file and the action metadata in the [`action.yml`](./action.yml) file.
+Update the action's name, description, branding, and inputs/outputs to match what your action does.
 
-### Testing the Action
+### `src/main.ts`
 
-Test files in this template are named `*.test.ts` and typically correspond to the source files being tested. This template uses [Vitest](https://vitest.dev/) as the testing framework. For more information on testing with Vitest, refer to [this documentation](https://vitest.dev/guide/).
+This is the action's entry point. Replace the example logic with your own. Use [`gha-utils`](https://github.com/threeal/gha-utils) to read inputs, write outputs, and log errors:
 
-After creating your test files, run tests with:
+```ts
+import { getInput, logError, setOutput } from "gha-utils";
+
+try {
+  const input = getInput("my-input");
+  // ... your action logic ...
+  setOutput("my-output", result);
+} catch (err) {
+  logError(err);
+  process.exitCode = 1;
+}
+```
+
+### `package.json`
+
+Update the `name` and any relevant fields to match your project.
+
+### `LICENSE`
+
+The template ships with the [Unlicense](https://unlicense.org/) (public domain). Replace it with the license you want, or leave it as-is.
+
+## Development Workflow
+
+Write your code in `src/`. When you're ready, just commit — the pre-commit hook will automatically:
+
+1. Install dependencies
+2. Format code (Prettier)
+3. Fix lint issues (ESLint)
+4. Type-check (TypeScript)
+5. Build the bundle (`dist/main.bundle.mjs`)
+
+If the hook reports errors, fix them and commit again. The `dist/` folder must be committed — it's what GitHub Actions runs.
+
+## Testing
+
+Add test files alongside source files as `*.test.ts`. Run all tests with:
 
 ```sh
 pnpm test
 ```
 
-Additionally, you can test the action by running it directly from the GitHub workflow as specified in the [`.github/workflows/ci.yaml`](./.github/workflows/ci.yaml) file.
+100% code coverage is enforced. Tests use [Vitest](https://vitest.dev/).
 
-### Release the Action
+## CI
 
-When the project is complete, release and publish it from the project repository page on GitHub. For more information on releasing a project, refer to [this documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases). For more information on publishing GitHub actions, refer to [this documentation](https://docs.github.com/en/actions/sharing-automations/creating-actions/publishing-actions-in-github-marketplace).
+`.github/workflows/ci.yaml` runs two jobs on every push and pull request:
+
+- **check** — validates the pre-commit hook and runs tests
+- **test** — runs the real action on Ubuntu, macOS, and Windows
+
+Update the `test` job to exercise your action's actual inputs and verify its outputs.
+
+## Releasing
+
+Tag a release on GitHub:
+
+```sh
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+Then create a GitHub Release from that tag. To make the action discoverable, [publish it to the GitHub Marketplace](https://docs.github.com/en/actions/sharing-automations/creating-actions/publishing-actions-in-github-marketplace) from the release page.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,3 @@
-# TODO: Modify the following metadata according to the project's specifications.
-
 name: Mkdir Action
 author: Alfi Maulana
 description: Create a new directory


### PR DESCRIPTION
Resolves #956.

## Summary

- Rewrites `README.md` with a minimal, step-by-step guide covering setup, customization, development workflow, testing, CI, and releasing
- Simplifies Lefthook description in `CLAUDE.md` — treats it as an external tool without mentioning dev dependency distinctions
- Removes stale `TODO` comment from `action.yml`

## Test plan

- [x] README renders correctly on GitHub
- [x] All links in README are valid
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)