### PR TITLE
Update CI runners to macos-15 and windows-2025

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-15, windows-2025]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Summary

- Bumps the test matrix from `macos-14` to `macos-15` and `windows-2022` to `windows-2025`

## Test plan

- [x] CI passes on all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)