### PR TITLE
Remove package.json customization section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ try {
 }
 ```
 
-### `package.json`
-
-Update the `name` and any relevant fields to match your project.
-
 ### `LICENSE`
 
 The template ships with the [Unlicense](https://unlicense.org/) (public domain). Replace it with the license you want, or leave it as-is.


### PR DESCRIPTION
## Summary

- Removes the `package.json` section from the "Customizing the Action" guide in README, since the `name` field is no longer something users need to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)