### PR TITLE
Improve test structure and mocking approach

### DIFF
--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -1,5 +1,5 @@
 import 'node:fs';
-import fsPromises from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import os from 'node:os';
 import 'node:path';
 
@@ -26,7 +26,7 @@ function logError(err) {
 
 try {
     const path = getInput("path");
-    await fsPromises.mkdir(path, { recursive: true });
+    await mkdir(path, { recursive: true });
 }
 catch (err) {
     logError(err);

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,34 +1,37 @@
-import fsPromises from "node:fs/promises";
-import os from "node:os";
-import { afterAll, beforeAll, beforeEach, expect, it, vi } from "vitest";
+import { access, mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeEach, expect, it, vi } from "vitest";
 
-beforeAll(() => {
-  process.chdir(os.tmpdir());
-});
+vi.mock("gha-utils");
+
+const tmpDir = path.resolve(import.meta.dirname, ".main.test.tmp");
 
 beforeEach(async () => {
-  await fsPromises.rm("path", { recursive: true, force: true });
+  await rm(tmpDir, { recursive: true, force: true });
+  await mkdir(tmpDir);
+  process.exitCode = undefined;
   vi.resetModules();
 });
 
+afterAll(() => rm(tmpDir, { recursive: true, force: true }));
+
 it("should create a directory recursively", async () => {
-  process.env.INPUT_PATH = "path/to/new/directory";
+  const { getInput } = await import("gha-utils");
+  vi.mocked(getInput).mockReturnValue(path.join(tmpDir, "new/directory"));
+
   await import("./main.js");
 
-  await fsPromises.access("path/to/new/directory");
+  await access(path.join(tmpDir, "new/directory"));
   expect(process.exitCode).toBeUndefined();
 });
 
 it("should fail to create a directory because a file already exists", async () => {
-  await fsPromises.writeFile("path", "a data");
+  await writeFile(path.join(tmpDir, "file"), "");
 
-  process.env.INPUT_PATH = "path/to/new/directory";
+  const { getInput } = await import("gha-utils");
+  vi.mocked(getInput).mockReturnValue(path.join(tmpDir, "file/child"));
+
   await import("./main.js");
 
   expect(process.exitCode).toBe(1);
-  process.exitCode = undefined;
-});
-
-afterAll(async () => {
-  await fsPromises.rm("path", { recursive: true, force: true });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
 import { getInput, logError } from "gha-utils";
-import fsPromises from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 
 try {
   const path = getInput("path");
-  await fsPromises.mkdir(path, { recursive: true });
+  await mkdir(path, { recursive: true });
 } catch (err) {
   logError(err);
   process.exitCode = 1;


### PR DESCRIPTION
## Summary

- Replace `process.env.INPUT_PATH` hacks with `vi.mock("gha-utils")` to properly mock `getInput` at the module level
- Use a local `.main.test.tmp` directory (in `src/`) instead of `os.tmpdir()`, scoped to the test file
- Reset `process.exitCode` in `beforeEach` instead of manually at the end of one test
- Use named imports from `node:fs/promises` in both `main.ts` and `main.test.ts`

## Test plan

- [x] All tests pass (`pnpm test`)
- [x] Pre-commit hook passes (`lefthook run pre-commit --all-files`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)