### PR TITLE
Bump Node.js to version 24.16.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=24.15.0
+use-node-version=24.16.0


### PR DESCRIPTION
This pull request updates the Node.js version specified in the `.npmrc` file to [24.16.0](https://github.com/nodejs/node/releases/tag/v24.16.0).