### PR TITLE
Remove redundant `test` script from `package.json`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
         run: lefthook run pre-commit --all-files
 
       - name: Test
-        run: pnpm test
+        run: pnpm vitest run
 
   test:
     name: Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```sh
-pnpm test                 # run all tests (Vitest)
-pnpm test <file>          # run a single test file
+pnpm vitest run           # run all tests (Vitest)
+pnpm vitest run <file>    # run a single test file
 pnpm tsc                  # type check
 pnpm eslint .             # lint
 pnpm prettier --check .   # check formatting

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If the hook reports errors, fix them and commit again. The `dist/` folder must b
 Add test files alongside source files as `*.test.ts`. Run all tests with:
 
 ```sh
-pnpm test
+pnpm vitest run
 ```
 
 100% code coverage is enforced. Tests use [Vitest](https://vitest.dev/).

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "root",
   "private": true,
   "type": "module",
-  "scripts": {
-    "test": "vitest run"
-  },
   "dependencies": {
     "ghakit": "^1.0.0"
   },


### PR DESCRIPTION
Removes the `test` script from `package.json`, which was just an alias for `vitest run`. The command is concise enough to invoke directly, so the alias adds no value.

## Changes

- Remove `scripts.test` from `package.json`
- Update CI workflow to call `pnpm vitest run` directly
- Update `CLAUDE.md` and `README.md` to reference `pnpm vitest run`

Closes #974