### PR TITLE
Rename bundled action entrypoint to main.js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,15 +13,15 @@ pnpm tsc                  # type check
 pnpm eslint .             # lint
 pnpm prettier --check .   # check formatting
 pnpm prettier --write .   # fix formatting
-pnpm rollup -c            # build — outputs dist/main.bundle.mjs
+pnpm rollup -c            # build — outputs dist/main.js
 ```
 
 Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/), set up with `lefthook install`. Hooks automatically run formatting, linting, type checking, and building before each commit. CI also validates the pre-commit hook by running `lefthook run pre-commit --all-files`.
 
 ## Architecture
 
-This is a Node.js 24 GitHub Action. The action's entry point is `dist/main.bundle.mjs`, produced by Rollup bundling `src/main.ts` into a single ESM file. The `dist/` folder must be committed — CI verifies there is no git diff after building.
+This is a Node.js 24 GitHub Action. The action's entry point is `dist/main.js`, produced by Rollup bundling `src/main.ts` into a single ESM file. The `dist/` folder must be committed — CI verifies there is no git diff after building.
 
 Source lives entirely in `src/`. Action logic lives in `src/action.ts` as an exported async function; `src/main.ts` is the entry point that calls it and handles error logging and exit codes. Use `ghakit` for anything GitHub Actions-related (reading inputs, writing outputs, logging, spawning processes, etc.). Tests use Vitest and must maintain 100% coverage (enforced in `vitest.config.ts`).
 
-The action is defined in `action.yml`, which declares inputs, outputs, and the Node.js runtime pointing to `dist/main.bundle.mjs`.
+The action is defined in `action.yml`, which declares inputs, outputs, and the Node.js runtime pointing to `dist/main.js`.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Write your code in `src/`. When you're ready, just commit — the pre-commit hoo
 2. Format code (Prettier)
 3. Fix lint issues (ESLint)
 4. Type-check (TypeScript)
-5. Build the bundle (`dist/main.bundle.mjs`)
+5. Build the bundle (`dist/main.js`)
 
 If the hook reports errors, fix them and commit again. The `dist/` folder must be committed — it's what GitHub Actions runs.
 

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: node24
-  main: dist/main.bundle.mjs
+  main: dist/main.js

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,39 @@
+import { EOL } from 'node:os';
+import 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import 'node:path';
+
+/**
+ * Logs an error message in GitHub Actions.
+ *
+ * @param err - The error, which can be of any type.
+ * @param options - Optional annotation parameters to pin the message to a file location.
+ */
+function logError(err, options) {
+    const message = err instanceof Error ? err.message : String(err);
+    const params = "";
+    process.stdout.write(`::error${params}::${message}${EOL}`);
+}
+
+/**
+ * Retrieves the value of a GitHub Actions input.
+ *
+ * Input names are matched case-insensitively — `getInput("token")` and
+ * `getInput("TOKEN")` both read the same `INPUT_TOKEN` env var.
+ *
+ * @param name - The name of the GitHub Actions input.
+ * @returns The value of the GitHub Actions input, or an empty string if not set.
+ */
+function getInput(name) {
+    return process.env[`INPUT_${name.toUpperCase()}`] ?? "";
+}
+
+async function mkdirAction() {
+    const path = getInput("path");
+    await mkdir(path, { recursive: true });
+}
+
+await mkdirAction().catch((err) => {
+    logError(err);
+    process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "root",
   "private": true,
   "type": "module",
-  "dependencies": {
-    "ghakit": "^1.0.0"
-  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@rollup/plugin-node-resolve": "^16.0.3",
@@ -13,6 +10,7 @@
     "@types/node": "^25.9.1",
     "@vitest/coverage-v8": "^4.1.7",
     "eslint": "^10.4.0",
+    "ghakit": "^1.0.0",
     "jiti": "^2.7.0",
     "prettier": "^3.8.3",
     "prettier-plugin-organize-imports": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      ghakit:
-        specifier: ^1.0.0
-        version: 1.0.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -33,6 +29,9 @@ importers:
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.7.0)
+      ghakit:
+        specifier: ^1.0.0
+        version: 1.0.0
       jiti:
         specifier: ^2.7.0
         version: 2.7.0

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,6 @@ export default {
   input: "src/main.ts",
   output: {
     dir: "dist",
-    entryFileNames: "[name].bundle.mjs",
   },
   plugins: [nodeResolve(), typescript()],
 };


### PR DESCRIPTION
Resolves #979.

## Summary

- Remove the custom `entryFileNames` from `rollup.config.js`, letting Rollup use its default `[name].js` — the bundle now outputs to `dist/main.js` instead of `dist/main.bundle.mjs`
- Update `action.yml` to point to `dist/main.js`
- Move `ghakit` from `dependencies` to `devDependencies`, since it is only used at build time and not included in the runtime distribution
- Update references in `README.md` and `CLAUDE.md`