### PR TITLE
Add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "typescript-eslint": "^8.60.0",
     "vitest": "^4.1.7"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "packageManager": "pnpm@10.33.4"
 }


### PR DESCRIPTION
This pull request resolves #985 by adding `"engines": { "node": ">=24" }` to `package.json` to complement the existing `use-node-version` in `.npmrc`.