### PR TITLE
Remove `packages` option from `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,2 @@
-packages:
-  - .
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
Removes the `packages` option from `pnpm-workspace.yaml`, simplifying the workspace configuration.

Resolves #1001.