### PR TITLE
Update CLAUDE.md to align style with nodejs-starter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,15 +16,7 @@ This is a minimal Node.js GitHub Action starter template written in TypeScript t
 - **`src/main.ts`** — Entry point that calls the action function and handles error logging and exit codes.
 - **`src/*.test.ts`** — Vitest test files co-located with source.
 
-### TypeScript Configuration
-
-- **`tsconfig.json`** — Type-check config with `noEmit: true`; used by `pnpm tsc`. Extends `@tsconfig/node24`, which sets `module: nodenext` and `moduleResolution: node16`. This requires import paths to use `.js` extensions even when importing `.ts` source files.
-
-### Build Configuration
-
-- **`tsup.config.ts`** — Configures tsup to bundle `src/main.ts` as ESM with tree-shaking enabled.
-
-### Build Output
+### Build Outputs
 
 - **`dist/main.js`** — Single bundled ESM file. Must be committed — CI verifies there is no git diff after building.
 
@@ -34,14 +26,56 @@ This is a minimal Node.js GitHub Action starter template written in TypeScript t
 
 ## Tooling
 
-- **pnpm** is the package manager. `devEngines.runtime` in `package.json` specifies the Node.js version (`onFail: "download"` triggers automatic download if needed); `packageManager` pins the pnpm version; `engines.node` asserts Node >=24.
-- **tsup** is the bundler. All packages — including runtime dependencies like `ghakit` — belong in `devDependencies`; tsup bundles everything so there are no runtime `dependencies` needed.
-- **ghakit** handles all GitHub Actions-specific concerns: reading inputs, writing outputs, logging, and spawning processes.
-- **ESLint** uses flat config (`eslint.config.ts`) with `@eslint/js` recommended rules and `typescript-eslint` strict + stylistic type-checked rules.
-- **Prettier** uses `prettier-plugin-organize-imports` — import order is auto-managed.
-- **Lefthook** manages Git hooks via `lefthook.yaml`. It is a standalone binary, not a pnpm package.
-- **Vitest** uses `vitest.config.ts` with coverage always enabled, text reporter, and 100% thresholds across all metrics.
-- **Dependabot** keeps GitHub Actions and npm dependencies up to date automatically via `.github/dependabot.yaml`.
+### Dependabot
+
+Keeps GitHub Actions and npm dependencies up to date automatically via `.github/dependabot.yaml`.
+
+### ESLint
+
+Linter configured in `eslint.config.ts`.
+
+### GitHub Actions
+
+Automates CI. Workflow files:
+
+- **`.github/workflows/ci.yaml`** — Triggers on push to `main`, pull requests, and manual dispatch.
+
+### Lefthook
+
+Git hook manager configured in `lefthook.yaml`.
+
+### pnpm
+
+Package manager. Also manages the Node.js runtime — versions for Node.js and pnpm are pinned in `package.json`.
+
+### Prettier
+
+Formatter configured in `.prettierrc.json` using `prettier-plugin-organize-imports` — import order is auto-managed.
+
+### tsup
+
+Bundler configured in `tsup.config.ts`. All packages — including runtime dependencies — belong in `devDependencies`; tsup bundles everything so there are no runtime `dependencies` needed.
+
+### TypeScript
+
+Type checker. `tsconfig.json` is used for type checking via `pnpm tsc`.
+
+The config sets `moduleResolution: node16`, which requires all import paths to use `.js` extensions — even when importing `.ts` source files.
+
+### Vitest
+
+Test runner configured in `vitest.config.ts` with 100% coverage threshold required on every test run.
+
+## Checking and Fixing
+
+Run the pre-commit hook:
+
+```sh
+lefthook run pre-commit              # staged files only (default)
+lefthook run pre-commit --all-files  # all files — matches what CI runs
+```
+
+If any file changes during the run, re-stage the changed files and retry.
 
 ## Testing
 
@@ -51,25 +85,3 @@ pnpm vitest run <file>      # Run a single test file
 ```
 
 Coverage is always enabled and computed for all files imported during the test run. Running a single test file may fail the 100% threshold if it imports a source file that another test is responsible for fully covering — use the full suite for accurate results.
-
-## Checking and Fixing
-
-Use Lefthook to run the same steps as the pre-commit hook:
-
-```sh
-lefthook run pre-commit              # staged files only (default)
-lefthook run pre-commit --all-files  # all files — matches what CI runs
-```
-
-This installs dependencies, fixes formatting, fixes lint, type-checks, and builds the action — in that order, stopping on the first failure. If any file changes during the run, it also fails and shows a diff of what changed — re-stage the changed files and retry.
-
-Individual commands (manual fallback if needed): `pnpm prettier --write .`, `pnpm eslint --fix`, `pnpm tsc`, `pnpm tsup`.
-
-## CI
-
-CI has two jobs:
-
-- **Check** — runs `lefthook run pre-commit --all-files` (install, format, lint, type-check, build), then runs the full test suite with `pnpm vitest run`.
-- **Test** — checks out the action itself and runs it on `ubuntu-24.04`, `macos-15`, and `windows-2025` to verify the actual action behavior end-to-end.
-
-See `.github/workflows/ci.yaml` for full details.


### PR DESCRIPTION
## Summary

- Restructured Tooling section to use alphabetical `###` subheadings, matching the style of [nodejs-starter](https://github.com/threeal/nodejs-starter)
- Moved TypeScript config details and devDependencies note into their respective tooling entries (`### TypeScript`, `### tsup`)
- Removed `### ghakit` from Tooling — it's a library, not a dev tool, and derived projects may use something else
- Removed `## CI` section — details belong in the workflow file; GitHub Actions tooling entry already covers it
- Fixed Architecture section order: Source Files → Build Outputs → Action Definition

## Test plan

- [ ] Review CLAUDE.md content for accuracy and style consistency with nodejs-starter

🤖 Generated with [Claude Code](https://claude.com/claude-code)