### PR TITLE
Bump pnpm to version 11.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "pnpm@11.9.0"
+  "packageManager": "pnpm@11.10.0"
 }


### PR DESCRIPTION
This pull request bumps pnpm to version [11.10.0](https://github.com/pnpm/pnpm/releases/tag/v11.10.0).