### PR TITLE
Reorder lefthook pre-commit steps

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -6,14 +6,14 @@ pre-commit:
     - name: install dependencies
       run: pnpm install
 
+    - name: check types
+      run: pnpm tsc
+
     - name: fix formatting
       run: pnpm prettier --write .
 
     - name: fix lint
       run: pnpm eslint --fix
-
-    - name: check types
-      run: pnpm tsc
 
     - name: build action
       run: pnpm tsup


### PR DESCRIPTION
## Summary

- `check types` now runs first, before the cosmetic `fix formatting`/`fix lint` steps, so compilation issues are caught before spending time on cosmetic fixes.
- `build action` now runs last, after formatting and lint fixes are applied, so the committed `dist/main.js` reflects the fully formatted and linted source rather than a pre-fix intermediate state.

Resolves #1043.