### PR TITLE
Simplify CI workflow description in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Linter configured in `eslint.config.ts`.
 
 Automates CI. Workflow files:
 
-- **`.github/workflows/ci.yaml`** — Triggers on push to `main`, pull requests, and manual dispatch. The `test` job tests the action in the CI environment — it's a placeholder to be updated or replaced to suit the actual action.
+- **`.github/workflows/ci.yaml`** — Triggers on push to `main`, pull requests, and manual dispatch.
 
 ### Lefthook
 


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s GitHub Actions section described only the `test` job (calling out that it's a placeholder), while `ci.yaml` also has a `check` job that runs the pre-commit hook and test suite — the doc gave an incomplete picture by naming one job and omitting the other. That job-specific detail is already covered by the README's "Customizing" section, so this drops it from `CLAUDE.md` entirely and matches the simpler phrasing used in the nodejs-starter template this project derives from.

- Before: `Triggers on push to main, pull requests, and manual dispatch. The test job tests the action in the CI environment — it's a placeholder to be updated or replaced to suit the actual action.`
- After: `Triggers on push to main, pull requests, and manual dispatch.`